### PR TITLE
Feature/54 preprocessing

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def main():
         sys.argv.remove("--refresh-data")
         run_data_pipeline()
 
-    gold_table = sys.argv[1] if len(sys.argv) > 1 else "80072ned_gold"
+    gold_table = sys.argv[1] if len(sys.argv) > 1 else "master_data_ml_preprocessed"
     model_key = sys.argv[2] if len(sys.argv) > 2 else "random_forest"
     features = sys.argv[3].split(",") if len(sys.argv) > 3 else None
 

--- a/src/data_engineering/data_loader_gold.py
+++ b/src/data_engineering/data_loader_gold.py
@@ -103,18 +103,32 @@ class DatabaseGold:
                 f_log("Master target dataframe is empty. Aborting master integration.", c_type="error")
                 return master_df
 
+            # Ensure consistent nomenclature for the target table
+            master_df = apply_gold_baseline(master_df, ML_TARGET_COLUMN)
+
             # Reconstruct raw SBI_COL from OHE columns so Tier 1 joins are possible.
             # OHE in transform_target_fact_table replaces the raw column with binary flags per value.
-            ohe_prefix = f"{SBI_COL}_"
-            ohe_cols = [c for c in master_df.columns if c.startswith(ohe_prefix)]
+            # CBS uses several naming variants for the SBI dimension — try them all.
+            sbi_ohe_prefixes = [
+                f"{SBI_COL}_",
+                "BedrijfstakkenSBI2008_",
+                "Bedrijfstakken_SBI2008_",
+                "SBI2008_",
+            ]
+            ohe_prefix = None
+            ohe_cols = []
+            for candidate_prefix in sbi_ohe_prefixes:
+                ohe_cols = [c for c in master_df.columns if c.startswith(candidate_prefix)]
+                if ohe_cols:
+                    ohe_prefix = candidate_prefix
+                    break
+
             if ohe_cols and SBI_COL not in master_df.columns:
                 master_df[SBI_COL] = master_df[ohe_cols].idxmax(axis=1).str.replace(ohe_prefix, "", regex=False)
-                f_log(f"Reconstructed '{SBI_COL}' from {len(ohe_cols)} OHE columns.", c_type="process")
+                f_log(f"Reconstructed '{SBI_COL}' from {len(ohe_cols)} OHE columns (prefix: '{ohe_prefix}').", c_type="process")
             elif SBI_COL not in master_df.columns:
-                # The gold table pre-dates OHE or was stored without SBI columns.
-                # All feature joins will fall back to Tier 2 (Broadcast). Re-run data_loader_gold.py to fix.
                 f_log(f"WARNING: '{SBI_COL}' not found in target and no OHE columns detected. "
-                      "All joins will be Tier 2 (Broadcast). Re-run data_loader_gold.py to regenerate gold tables.", c_type="warning")
+                      "All feature joins will fall back to Tier 2 (Broadcast).", c_type="warning")
 
             sbi_count = master_df[SBI_COL].nunique() if SBI_COL in master_df.columns else 0
             f_log(f"Master target loaded: {len(master_df)} rows across {sbi_count} unique SBI branches.", c_type="process")
@@ -145,10 +159,20 @@ class DatabaseGold:
                         f_log(f"Skipping {table}: missing '{DATE_COL}', cannot align temporally.", c_type="warning")
                         continue
 
-                    has_sbi = SBI_COL in feature_df.columns
+                    # Tier 1 requires SBI on BOTH the feature table AND the master table
+                    has_sbi = SBI_COL in feature_df.columns and SBI_COL in master_df.columns
                     active_keys = [DATE_COL, SBI_COL] if has_sbi else [DATE_COL]
                     tier_label = "Tier 1 (SBI-specific)" if has_sbi else "Tier 2 (Broadcast)"
                     f_log(f"{tier_label} join selected for: {table}", c_type="info")
+
+                    # Guard: Tier 2 tables with multiple rows per date must be aggregated
+                    # to prevent Cartesian explosions (N_master × N_feature per quarter).
+                    if not has_sbi and feature_df.duplicated(subset=[DATE_COL]).any():
+                        numeric_feature_cols = feature_df.select_dtypes(include="number").columns.tolist()
+                        pre_agg_rows = len(feature_df)
+                        feature_df = feature_df.groupby(DATE_COL, as_index=False)[numeric_feature_cols].mean()
+                        f_log(f"Aggregated {table} from {pre_agg_rows} -> {len(feature_df)} rows "
+                              f"(mean across sectors) to prevent Cartesian explosion.", c_type="warning")
 
                     # Preemptive overlap dropping to prevent _x/_y suffixes
                     overlap = set(feature_df.columns).intersection(set(master_df.columns)) - set(active_keys)
@@ -252,7 +276,19 @@ def apply_gold_baseline(df: pd.DataFrame, ml_target_col: str = None) -> pd.DataF
     
     df = df.drop(columns=cols_to_drop, errors='ignore')
 
-    # Drop NaNs on specific crucial identifier 
+    # 4. Normalize SBI Column Nomenclature
+    # Standardizes various CBS sector column names into a project-wide structural key consistent for joins.
+    sbi_variants = ['BedrijfstakkenSBI2008', 'Bedrijfstakken_SBI2008', 'SBI2008', 'BedrijfstakkenBranches_SBI2008']
+    target_sbi = 'BedrijfstakkenBranchesSBI2008'
+    
+    if target_sbi not in df.columns:
+        for variant in sbi_variants:
+            if variant in df.columns:
+                df = df.rename(columns={variant: target_sbi})
+                f_log(f"Normalized structural key '{variant}' -> '{target_sbi}'", c_type="process")
+                break
+
+    # 5. Drop NaNs on specific crucial identifier 
     if 'period_enddate' in df.columns:
         df = df.dropna(subset=['period_enddate'])
 

--- a/src/data_engineering/data_loader_gold.py
+++ b/src/data_engineering/data_loader_gold.py
@@ -178,14 +178,29 @@ class DatabaseGold:
         f_log(f"Tier 1 (SBI-specific, {len(sbi_joined)} tables): {sbi_joined or 'None'}", c_type="info")
         f_log(f"Tier 2 (Broadcast/no SBI, {len(broadcast_joined)} tables — ADD SBI DIMENSION): {broadcast_joined or 'None'}", c_type="warning")
 
-        # 4. Storage Persistence
+        # 4. Storage Persistence (joined, pre-imputation)
         try:
-            master_df.to_sql("master_data_ml", self.engine, if_exists="replace", index=False)
-            f_log("Stored master_data_ml successfully.", c_type="store")
+            master_df.to_sql("master_data_ml_joined", self.engine, if_exists="replace", index=False)
+            f_log("Stored master_data_ml_joined successfully.", c_type="store")
         except Exception as e:
-            f_log(f"Failed to save master_data_ml: {e}", c_type="error")
+            f_log(f"Failed to save master_data_ml_joined: {e}", c_type="error")
 
-        f_log(f"Completed master dataset creation. Final shape: {master_df.shape}", c_type="complete")
+        f_log(f"Completed master dataset join. Shape: {master_df.shape}", c_type="complete")
+
+        # 5. Preprocessing Gate: validate → impute → validate → persist
+        from src.ml_engineering.model_preprocess import validate_master_dataset, impute_missing_values
+
+        validate_master_dataset(master_df, stage="raw")
+        preprocessed_df = impute_missing_values(master_df)
+        validate_master_dataset(preprocessed_df, stage="clean")
+
+        try:
+            preprocessed_df.to_sql("master_data_ml_preprocessed", self.engine, if_exists="replace", index=False)
+            f_log("Stored master_data_ml_preprocessed successfully.", c_type="store")
+        except Exception as e:
+            f_log(f"Failed to save master_data_ml_preprocessed: {e}", c_type="error")
+
+        f_log(f"Completed full preprocessing pipeline. Final shape: {preprocessed_df.shape}", c_type="complete")
         return master_df
 
 

--- a/src/ml_engineering/model_orchestrator.py
+++ b/src/ml_engineering/model_orchestrator.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     
     orch = ModelOrchestrator("80072ned_SickLeave", "RF_SickLeave")
     orch.run_experiment(
-        gold_table="80072ned_gold",
+        gold_table="master_data_ml_preprocessed",
         experiment_config=ConfigRegistry.get("random_forest"),
         threshold_r2=0.0
     )

--- a/src/ml_engineering/model_preprocess.py
+++ b/src/ml_engineering/model_preprocess.py
@@ -1,0 +1,181 @@
+"""
+Preprocessing module for the ML-ready master dataset.
+
+Provides two public functions:
+- validate_master_dataset(): schema and integrity checks before/after imputation
+- impute_missing_values(): deterministic null-safe imputation with missing indicators
+
+All operations are pure (no side-effects beyond logging) and type-annotated.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, List
+
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+
+from src.utils.m_log import f_log
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+DATE_COL = "period_enddate"
+SBI_COL = "BedrijfstakkenBranchesSBI2008"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate_master_dataset(
+    df: pd.DataFrame,
+    *,
+    stage: Literal["raw", "clean"],
+) -> pd.DataFrame:
+    """
+    Run integrity checks on the master dataset at a given pipeline stage.
+
+    Args:
+        df: The master DataFrame to validate.
+        stage: 'raw' (pre-imputation, soft checks) or 'clean' (post-imputation, strict).
+
+    Returns:
+        The same DataFrame unchanged (enables call-chaining).
+
+    Raises:
+        ValueError: If any strict check fails (clean stage only).
+    """
+    f_log(f"--- Validation Gate [{stage.upper()}] ---", c_type="process")
+
+    # 1. Temporal key must be present
+    if DATE_COL not in df.columns:
+        raise ValueError(f"Required column '{DATE_COL}' is missing from the dataset.")
+    f_log(f"✅ '{DATE_COL}' column present.", c_type="success")
+
+    # 2. Duplicate key rows
+    key_cols = [DATE_COL, SBI_COL] if SBI_COL in df.columns else [DATE_COL]
+    duplicate_count = df.duplicated(subset=key_cols).sum()
+    if duplicate_count > 0:
+        raise ValueError(
+            f"{duplicate_count} duplicate rows detected on key columns {key_cols}."
+        )
+    f_log(f"✅ No duplicate key rows ({key_cols}).", c_type="success")
+
+    # 3. Missing-value assessment
+    total_nulls = df.isna().sum().sum()
+    if stage == "raw":
+        # Soft log: report NaN density per column for engineer visibility
+        nan_cols = df.columns[df.isna().any()].tolist()
+        if nan_cols:
+            pct_missing = (df.isna().sum() / len(df) * 100).round(1)
+            top_missing = pct_missing[pct_missing > 0].sort_values(ascending=False).head(10)
+            f_log(f"⚠️ {len(nan_cols)} columns contain NaNs ({total_nulls} total). "
+                  f"Top missing %: {top_missing.to_dict()}", c_type="warning")
+        else:
+            f_log("✅ No missing values.", c_type="success")
+    else:
+        # Strict: zero NaNs required after preprocessing
+        if total_nulls > 0:
+            raise ValueError(
+                f"Post-imputation dataset still contains {total_nulls} NaN values."
+            )
+        f_log("✅ Zero missing values confirmed.", c_type="success")
+
+    # 4. Float64 enforcement (clean stage only)
+    if stage == "clean":
+        non_float = [c for c in df.columns if df[c].dtype != np.float64]
+        if non_float:
+            raise ValueError(
+                f"Columns not float64: {non_float[:10]}{'...' if len(non_float) > 10 else ''}"
+            )
+        f_log("✅ All columns are float64.", c_type="success")
+
+    f_log(f"✅ Validation gate [{stage.upper()}] passed. Shape: {df.shape}", c_type="success")
+    return df
+
+
+def _identify_ohe_columns(df: pd.DataFrame) -> List[str]:
+    """Return columns that are binary OHE flags (values exclusively in {0, 1, NaN})."""
+    ohe_cols = []
+    for col in df.select_dtypes(include=[np.number]).columns:
+        unique_vals = df[col].dropna().unique()
+        if len(unique_vals) <= 2 and set(unique_vals).issubset({0.0, 1.0}):
+            ohe_cols.append(col)
+    return ohe_cols
+
+
+def impute_missing_values(
+    df: pd.DataFrame,
+    *,
+    numeric_strategy: str = "median",
+    add_missing_indicator: bool = True,
+) -> pd.DataFrame:
+    """
+    Return a fully imputed copy of *df* with all columns cast to float64.
+
+    Imputation tiers:
+    - Binary OHE flags ({0, 1, NaN}) → filled with 0 (absent = not observed)
+    - Remaining numeric columns → SimpleImputer(strategy=numeric_strategy)
+    - Non-numeric columns → dropped (should not exist in a Gold table)
+
+    Args:
+        df: Input DataFrame (typically master_data_ml_joined).
+        numeric_strategy: 'median' (default, robust to skew) or 'mean'.
+        add_missing_indicator: If True, creates <col>_is_missing binary flags.
+
+    Returns:
+        A new DataFrame with zero NaNs, all float64.
+    """
+    result = df.copy()
+    f_log(f"Starting imputation. Input shape: {result.shape}, "
+          f"total NaNs: {result.isna().sum().sum()}", c_type="process")
+
+    # 1. Capture missing-indicator flags BEFORE any imputation
+    if add_missing_indicator:
+        cols_with_nans = result.columns[result.isna().any()].tolist()
+        missing_flags = result[cols_with_nans].isna().astype(float)
+        missing_flags.columns = [f"{c}_is_missing" for c in cols_with_nans]
+        f_log(f"Created {len(cols_with_nans)} missing-indicator columns.", c_type="info")
+
+    # 2. Drop non-numeric columns (should already be absent in Gold, but safety net)
+    non_numeric_cols = result.select_dtypes(exclude=[np.number]).columns.tolist()
+    if non_numeric_cols:
+        f_log(f"Dropping {len(non_numeric_cols)} non-numeric columns: "
+              f"{non_numeric_cols[:5]}{'...' if len(non_numeric_cols) > 5 else ''}", c_type="warning")
+        result = result.drop(columns=non_numeric_cols)
+
+    # 3. Separate OHE flags from continuous numeric columns
+    ohe_cols = _identify_ohe_columns(result)
+    numeric_cols = [c for c in result.columns if c not in ohe_cols]
+
+    # 4. Impute OHE flags with 0 (absent = not observed)
+    if ohe_cols:
+        result[ohe_cols] = result[ohe_cols].fillna(0.0)
+        f_log(f"Imputed {len(ohe_cols)} OHE columns with 0.", c_type="info")
+
+    # 5. Impute continuous numeric columns with median/mean
+    cols_needing_imputation = [c for c in numeric_cols if result[c].isna().any()]
+    if cols_needing_imputation:
+        imputer = SimpleImputer(strategy=numeric_strategy)
+        result[cols_needing_imputation] = imputer.fit_transform(
+            result[cols_needing_imputation]
+        )
+        f_log(f"Imputed {len(cols_needing_imputation)} numeric columns "
+              f"with {numeric_strategy}.", c_type="info")
+
+    # 6. Append missing-indicator columns
+    if add_missing_indicator and len(cols_with_nans) > 0:
+        # Only keep indicators for columns that survived the drop step
+        surviving_indicators = [c for c in missing_flags.columns
+                                if c.replace("_is_missing", "") in result.columns]
+        result = pd.concat([result, missing_flags[surviving_indicators]], axis=1)
+
+    # 7. Cast everything to float64 (MLflow / Gold Policy)
+    result = result.astype("float64")
+
+    f_log(f"Imputation complete. Output shape: {result.shape}, "
+          f"remaining NaNs: {result.isna().sum().sum()}", c_type="success")
+    return result

--- a/src/ml_engineering/model_preprocess.py
+++ b/src/ml_engineering/model_preprocess.py
@@ -56,13 +56,21 @@ def validate_master_dataset(
     f_log(f"✅ '{DATE_COL}' column present.", c_type="success")
 
     # 2. Duplicate key rows
-    key_cols = [DATE_COL, SBI_COL] if SBI_COL in df.columns else [DATE_COL]
+    has_full_key = SBI_COL in df.columns
+    key_cols = [DATE_COL, SBI_COL] if has_full_key else [DATE_COL]
     duplicate_count = df.duplicated(subset=key_cols).sum()
     if duplicate_count > 0:
-        raise ValueError(
-            f"{duplicate_count} duplicate rows detected on key columns {key_cols}."
-        )
-    f_log(f"✅ No duplicate key rows ({key_cols}).", c_type="success")
+        if has_full_key:
+            # Full composite key available but still duplicates → real data issue
+            raise ValueError(
+                f"{duplicate_count} duplicate rows detected on composite key {key_cols}."
+            )
+        # Date-only key: duplicates are expected (multiple SBI sectors per quarter)
+        f_log(f"⚠️ {duplicate_count} duplicate rows on {key_cols}. "
+              f"Expected: multiple SBI sectors share the same date key.",
+              c_type="warning")
+    else:
+        f_log(f"✅ No duplicate key rows ({key_cols}).", c_type="success")
 
     # 3. Missing-value assessment
     total_nulls = df.isna().sum().sum()
@@ -84,14 +92,15 @@ def validate_master_dataset(
             )
         f_log("✅ Zero missing values confirmed.", c_type="success")
 
-    # 4. Float64 enforcement (clean stage only)
+    # 4. Float64 enforcement (clean stage only, excludes structural keys)
     if stage == "clean":
-        non_float = [c for c in df.columns if df[c].dtype != np.float64]
+        feature_cols = [c for c in df.columns if c not in (DATE_COL, SBI_COL)]
+        non_float = [c for c in feature_cols if df[c].dtype != np.float64]
         if non_float:
             raise ValueError(
                 f"Columns not float64: {non_float[:10]}{'...' if len(non_float) > 10 else ''}"
             )
-        f_log("✅ All columns are float64.", c_type="success")
+        f_log("✅ All feature columns are float64.", c_type="success")
 
     f_log(f"✅ Validation gate [{stage.upper()}] passed. Shape: {df.shape}", c_type="success")
     return df
@@ -133,6 +142,12 @@ def impute_missing_values(
     f_log(f"Starting imputation. Input shape: {result.shape}, "
           f"total NaNs: {result.isna().sum().sum()}", c_type="process")
 
+    # 0. Extract structural keys — these are the dataset's spine, not features
+    structural_keys = [c for c in [DATE_COL, SBI_COL] if c in result.columns]
+    key_data = result[structural_keys].copy() if structural_keys else None
+    result = result.drop(columns=structural_keys, errors="ignore")
+    f_log(f"Preserved {len(structural_keys)} structural keys: {structural_keys}", c_type="info")
+
     # 1. Capture missing-indicator flags BEFORE any imputation
     if add_missing_indicator:
         cols_with_nans = result.columns[result.isna().any()].tolist()
@@ -173,8 +188,12 @@ def impute_missing_values(
                                 if c.replace("_is_missing", "") in result.columns]
         result = pd.concat([result, missing_flags[surviving_indicators]], axis=1)
 
-    # 7. Cast everything to float64 (MLflow / Gold Policy)
+    # 7. Cast feature columns to float64 (MLflow / Gold Policy)
     result = result.astype("float64")
+
+    # 8. Re-attach structural keys at the front of the DataFrame
+    if key_data is not None:
+        result = pd.concat([key_data.reset_index(drop=True), result.reset_index(drop=True)], axis=1)
 
     f_log(f"Imputation complete. Output shape: {result.shape}, "
           f"remaining NaNs: {result.isna().sum().sum()}", c_type="success")

--- a/tests/test_model_preprocess.py
+++ b/tests/test_model_preprocess.py
@@ -117,13 +117,21 @@ class TestValidation(unittest.TestCase):
             validate_master_dataset(df, stage="clean")
         self.assertIn("NaN", str(ctx.exception))
 
-    def test_validate_catches_duplicate_keys(self) -> None:
-        """Validation raises ValueError on duplicate key rows."""
+    def test_validate_raw_allows_duplicates(self) -> None:
+        """Validation soft-warns on date-only duplicates (SBI absent)."""
         df = _make_numeric_only_df(include_nans=False)
-        # Create a duplicate row by repeating index 0
         df_dup = pd.concat([df, df.iloc[[0]]], ignore_index=True)
+        # Should NOT raise — no SBI column means date-only duplicates are expected
+        returned = validate_master_dataset(df_dup, stage="raw")
+        self.assertIsNotNone(returned)
+
+    def test_validate_catches_composite_key_duplicates(self) -> None:
+        """Validation raises ValueError when full composite key has duplicates."""
+        df = _make_synthetic_df(include_nans=False)
+        df_dup = pd.concat([df, df.iloc[[0]]], ignore_index=True)
+        # SBI column IS present → composite key duplicates are a real error
         with self.assertRaises(ValueError) as ctx:
-            validate_master_dataset(df_dup, stage="raw")
+            validate_master_dataset(df_dup, stage="clean")
         self.assertIn("duplicate", str(ctx.exception).lower())
 
 

--- a/tests/test_model_preprocess.py
+++ b/tests/test_model_preprocess.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for src/ml_engineering/model_preprocess.py.
+
+All tests use synthetic DataFrames — no database access required.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.ml_engineering.model_preprocess import (
+    validate_master_dataset,
+    impute_missing_values,
+    _identify_ohe_columns,
+)
+
+
+def _make_synthetic_df(include_nans: bool = True) -> pd.DataFrame:
+    """Build a small synthetic DataFrame mimicking master_data_ml_joined."""
+    data = {
+        "period_enddate": pd.to_datetime([
+            "2019-03-31", "2019-06-30", "2019-09-30", "2019-12-31",
+            "2020-03-31", "2020-06-30", "2020-09-30", "2020-12-31",
+            "2021-03-31", "2021-06-30",
+        ]).astype("float64"),
+        "BedrijfstakkenBranchesSBI2008": [
+            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J"
+        ],
+        "stress_rate": [1.2, 2.3, np.nan, 4.1, 3.5, np.nan, 2.9, 1.1, 0.8, 3.3],
+        "employment_pct": [65.0, 70.0, 68.0, np.nan, 72.0, 74.0, np.nan, 69.0, 71.0, 73.0],
+        "SBI_flag_A": [1.0, 0.0, 0.0, 1.0, np.nan, 0.0, 1.0, 0.0, 0.0, 1.0],
+        "SBI_flag_B": [0.0, 1.0, np.nan, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0],
+    }
+    df = pd.DataFrame(data)
+    if not include_nans:
+        df = df.fillna(0.0)
+    return df
+
+
+def _make_numeric_only_df(include_nans: bool = True) -> pd.DataFrame:
+    """Build a fully numeric synthetic DataFrame (no string columns)."""
+    df = _make_synthetic_df(include_nans=include_nans)
+    df = df.drop(columns=["BedrijfstakkenBranchesSBI2008"])
+    return df
+
+
+class TestImputation(unittest.TestCase):
+    """Tests for impute_missing_values()."""
+
+    def test_impute_numeric_median(self) -> None:
+        """Numeric NaN values are filled with the column median."""
+        df = _make_numeric_only_df(include_nans=True)
+        result = impute_missing_values(df, add_missing_indicator=False)
+
+        # stress_rate: non-NaN values [1.2, 2.3, 4.1, 3.5, 2.9, 1.1, 0.8, 3.3] → median = 2.6
+        stress_median = pd.Series([1.2, 2.3, 4.1, 3.5, 2.9, 1.1, 0.8, 3.3]).median()
+        self.assertAlmostEqual(result["stress_rate"].iloc[2], stress_median, places=5)
+
+    def test_impute_ohe_zeros(self) -> None:
+        """Binary OHE flag NaN values are filled with 0."""
+        df = _make_numeric_only_df(include_nans=True)
+        result = impute_missing_values(df, add_missing_indicator=False)
+
+        # SBI_flag_A had NaN at index 4 → should be 0.0
+        self.assertEqual(result["SBI_flag_A"].iloc[4], 0.0)
+        # SBI_flag_B had NaN at index 2 → should be 0.0
+        self.assertEqual(result["SBI_flag_B"].iloc[2], 0.0)
+
+    def test_missing_indicator_columns(self) -> None:
+        """Missing-indicator columns are created for columns that had NaNs."""
+        df = _make_numeric_only_df(include_nans=True)
+        result = impute_missing_values(df, add_missing_indicator=True)
+
+        expected_indicators = [
+            "stress_rate_is_missing",
+            "employment_pct_is_missing",
+            "SBI_flag_A_is_missing",
+            "SBI_flag_B_is_missing",
+        ]
+        for indicator in expected_indicators:
+            self.assertIn(indicator, result.columns)
+
+        # stress_rate had NaN at index 2 → indicator should be 1.0
+        self.assertEqual(result["stress_rate_is_missing"].iloc[2], 1.0)
+        # stress_rate was NOT NaN at index 0 → indicator should be 0.0
+        self.assertEqual(result["stress_rate_is_missing"].iloc[0], 0.0)
+
+    def test_no_nan_after_impute(self) -> None:
+        """Output DataFrame has zero NaN values."""
+        df = _make_numeric_only_df(include_nans=True)
+        result = impute_missing_values(df)
+        self.assertEqual(result.isna().sum().sum(), 0)
+
+    def test_all_float64_after_impute(self) -> None:
+        """All output columns are float64."""
+        df = _make_numeric_only_df(include_nans=True)
+        result = impute_missing_values(df)
+        for col in result.columns:
+            self.assertEqual(result[col].dtype, np.float64, f"Column '{col}' is not float64")
+
+
+class TestValidation(unittest.TestCase):
+    """Tests for validate_master_dataset()."""
+
+    def test_validate_raw_passes(self) -> None:
+        """Raw validation passes on a valid synthetic DataFrame with NaNs."""
+        df = _make_numeric_only_df(include_nans=True)
+        # Should return without raising
+        returned = validate_master_dataset(df, stage="raw")
+        self.assertIs(returned, df)
+
+    def test_validate_clean_catches_nan(self) -> None:
+        """Clean validation raises ValueError if NaNs remain."""
+        df = _make_numeric_only_df(include_nans=True)
+        with self.assertRaises(ValueError) as ctx:
+            validate_master_dataset(df, stage="clean")
+        self.assertIn("NaN", str(ctx.exception))
+
+    def test_validate_catches_duplicate_keys(self) -> None:
+        """Validation raises ValueError on duplicate key rows."""
+        df = _make_numeric_only_df(include_nans=False)
+        # Create a duplicate row by repeating index 0
+        df_dup = pd.concat([df, df.iloc[[0]]], ignore_index=True)
+        with self.assertRaises(ValueError) as ctx:
+            validate_master_dataset(df_dup, stage="raw")
+        self.assertIn("duplicate", str(ctx.exception).lower())
+
+
+class TestOHEDetection(unittest.TestCase):
+    """Tests for the internal _identify_ohe_columns() helper."""
+
+    def test_identifies_binary_columns(self) -> None:
+        """Correctly identifies columns with values in {0, 1, NaN}."""
+        df = _make_numeric_only_df(include_nans=True)
+        ohe_cols = _identify_ohe_columns(df)
+        self.assertIn("SBI_flag_A", ohe_cols)
+        self.assertIn("SBI_flag_B", ohe_cols)
+        self.assertNotIn("stress_rate", ohe_cols)
+        self.assertNotIn("employment_pct", ohe_cols)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The preprocessing step sits between the Gold join layer and the ML training layer, it outputs a fully dense master_data_ml_preprocessed matrix with zero nulls, all float64, and a complementary set of missing‑indicator columns.

Pre‑validate (stage="raw") – confirms schema integrity before we touch the data.
Post‑validate (stage="clean") – confirms correctness after imputation.